### PR TITLE
lib/WorkBook.js: refactored .write method to .writeToBuffer and .write

### DIFF
--- a/lib/WorkBook.js
+++ b/lib/WorkBook.js
@@ -223,7 +223,7 @@ exports.WorkBook = function(){
 		debug:false
 	}
 
-	this.write = function(fileName, response){
+	this.writeToBuffer = function(){
 		var xlsx = new jszip();
 		var xmlOutVars = {};
 		var xmlDebugVars = { pretty: true, indent: '  ',newline: '\n' };
@@ -365,8 +365,11 @@ exports.WorkBook = function(){
 		xlsx.folder("xl").file("workbook.xml",wbXML.end(xmlOutVars));
 		xlsx.folder("xl").folder("_rels").file("workbook.xml.rels",relsXML.end(xmlOutVars));
 
-		var buffer = xlsx.generate({type:"nodebuffer"});
+		return xlsx.generate({type:"nodebuffer"});
+	}
 
+	this.write = function(fileName, response){
+		var buffer = this.writeToBuffer();
 		if(response == undefined){
 			fs.writeFile(fileName, buffer, function(err) {
 			  if (err) throw err;


### PR DESCRIPTION
Thus one could get the buffer that was generated by xlsx before it would be written out. Which is useful for when one would want to write it out to an alternative stream.

We use it in our project to write multiple excel files directly to [zip-stream](https://github.com/ctalkington/node-zip-stream) entries.
