### PR TITLE
Add a callback when writing to the filesystem.

### DIFF
--- a/lib/WorkBook.js
+++ b/lib/WorkBook.js
@@ -457,11 +457,9 @@ exports.WorkBook = function(){
 
 	this.write = function(fileName, response){
 		var buffer = this.writeToBuffer();
-		if(response == undefined){
-			fs.writeFile(fileName, buffer, function(err) {
-			  if (err) throw err;
-			});
-		}else{
+
+		// If `response` is an object (a node response object)
+		if(typeof response === "object"){
 			response.writeHead(200,{
 				'Content-Length':buffer.length,
 				'Content-Type':'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
@@ -469,7 +467,22 @@ exports.WorkBook = function(){
 			});
 			response.end(buffer);
 		}
+
+		// Else if `response` is a function, use it as a callback
+		else if(typeof response === "function"){
+			fs.writeFile(fileName, buffer, function(err) {
+				response(err);
+			});
+		}
+
+		// Else response wasn't specified
+		else {
+			fs.writeFile(fileName, buffer, function(err) {
+				if (err) throw err;
+			})
+		}
 	}
+
 	return this;
 }
 


### PR DESCRIPTION
The WorkBook write function can now be called in three different ways:

`workbook.write(filename)`
    will asynchonrously write the workbook to the specified file.

`workbook.write(filename, response)`
    will write the workbook to the node response object.

`workbook.write(filename, callback)`
    will write the workbook to the specified file, and call the callback
    function when the process has completed (or errored).

This fixes #4.
