### PR TITLE
Added Right-To-Left layout option to Worksheet

### DIFF
--- a/lib/WorkSheet.js
+++ b/lib/WorkSheet.js
@@ -23,6 +23,7 @@ var WorkSheet = function(wb){
 	}
 	this.sheetView = {
 		workbookViewId:0,
+		rightToLeft:0,
 		zoomScale:100,
 		zoomScaleNormal:100,
 		zoomScalePageLayoutView:100
@@ -159,6 +160,10 @@ function setWSOpts(opts){
 		this.sheetView.zoomScale = opts.view.zoom?opts.view.zoom:100;
 		this.sheetView.zoomScaleNormal = opts.view.zoom?opts.view.zoom:100;
 		this.sheetView.zoomScalePageLayoutView = opts.view.zoom?opts.view.zoom:100;
+		
+		if (opts.view.rtl) {
+			this.sheetView.rightToLeft = 1;
+		}
 	}
 
 	// Set Outline Options
@@ -183,6 +188,7 @@ function setWSOpts(opts){
 	thisView.push({'@zoomScale':this.sheetView.zoomScale?this.sheetView.zoomScale:100});
 	thisView.push({'@zoomScaleNormal':this.sheetView.zoomScaleNormal?this.sheetView.zoomScaleNormal:100});
 	thisView.push({'@zoomScalePageLayoutView':this.sheetView.zoomScalePageLayoutView?this.sheetView.zoomScalePageLayoutView:100});
+	thisView.push({'@rightToLeft':this.sheetView.rightToLeft?1:0});
 }
 
 function toXML(){


### PR DESCRIPTION
This allows people who create Excel files for RTL languages (Hebrew, Arabic, etc.) to set a Right-To-Left layout for a worksheet.