### PR TITLE
Fix Workbook#createStyle creating duplicates and slow performance

### DIFF
--- a/source/lib/style/style.js
+++ b/source/lib/style/style.js
@@ -9,21 +9,19 @@ const NumberFormat = require('./classes/numberFormat.js');
 
 let _getFontId = (wb, font) => {
 
+    // Create the Font and lookup key
     font = _.merge({}, wb.opts.defaultFont, font);
-    let thisFont = new Font(font);
+    const thisFont = new Font(font);
+    const lookupKey = JSON.stringify(thisFont.toObject());
 
-    let fontId;
-    wb.styleData.fonts.forEach((f, i) => {
-        if (_.isEqual(thisFont.toObject(), f.toObject())) {
-            fontId = i;
-        }
-    });
-    if (fontId === undefined) {
-        let count = wb.styleData.fonts.push(thisFont);
-        fontId = count - 1;
+    // Find an existing entry, creating a new one if it does not exist
+    let id = wb.styleDataLookup.fonts[lookupKey];
+    if (id == null) {
+        id = wb.styleData.fonts.push(thisFont) - 1;
+        wb.styleDataLookup.fonts[lookupKey] = id;
     }
 
-    return fontId;
+    return id;
 };
 
 let _getFillId = (wb, fill) => {
@@ -31,20 +29,18 @@ let _getFillId = (wb, fill) => {
         return null;
     }
 
-    let thisFill = new Fill(fill);
+    // Create the Fill and lookup key
+    const thisFill = new Fill(fill);
+    const lookupKey = JSON.stringify(thisFill.toObject());
 
-    let fillId;
-    wb.styleData.fills.forEach((f, i) => {
-        if (_.isEqual(thisFill.toObject(), f.toObject())) {
-            fillId = i;
-        }
-    });
-    if (fillId === undefined) {
-        let count = wb.styleData.fills.push(thisFill);
-        fillId = count - 1;
+    // Find an existing entry, creating a new one if it does not exist
+    let id = wb.styleDataLookup.fills[lookupKey];
+    if (id == null) {
+        id = wb.styleData.fills.push(thisFill) - 1;
+        wb.styleDataLookup.fills[lookupKey] = id;
     }
 
-    return fillId;
+    return id;
 };
 
 let _getBorderId = (wb, border) => {
@@ -52,20 +48,18 @@ let _getBorderId = (wb, border) => {
         return null;
     }
 
-    let thisBorder = new Border(border);
-    let borderId;
-    wb.styleData.borders.forEach((b, i) => {
-        if (_.isEqual(b.toObject(), thisBorder.toObject())) {
-            borderId = i;
-        }
-    });
+    // Create the Border and lookup key
+    const thisBorder = new Border(border);
+    const lookupKey = JSON.stringify(thisBorder.toObject());
 
-    if (borderId === undefined) {
-        let count = wb.styleData.borders.push(thisBorder);
-        borderId = count - 1;
+    // Find an existing entry, creating a new one if it does not exist
+    let id = wb.styleDataLookup.borders[lookupKey];
+    if (id == null) {
+        id = wb.styleData.borders.push(thisBorder) - 1;
+        wb.styleDataLookup.borders[lookupKey] = id;
     }
 
-    return borderId;
+    return id;
 };
 
 let _getNumFmt = (wb, val) => {

--- a/source/lib/style/style.js
+++ b/source/lib/style/style.js
@@ -16,7 +16,7 @@ let _getFontId = (wb, font) => {
 
     // Find an existing entry, creating a new one if it does not exist
     let id = wb.styleDataLookup.fonts[lookupKey];
-    if (id == null) {
+    if (id === undefined) {
         id = wb.styleData.fonts.push(thisFont) - 1;
         wb.styleDataLookup.fonts[lookupKey] = id;
     }
@@ -35,7 +35,7 @@ let _getFillId = (wb, fill) => {
 
     // Find an existing entry, creating a new one if it does not exist
     let id = wb.styleDataLookup.fills[lookupKey];
-    if (id == null) {
+    if (id === undefined) {
         id = wb.styleData.fills.push(thisFill) - 1;
         wb.styleDataLookup.fills[lookupKey] = id;
     }
@@ -54,7 +54,7 @@ let _getBorderId = (wb, border) => {
 
     // Find an existing entry, creating a new one if it does not exist
     let id = wb.styleDataLookup.borders[lookupKey];
-    if (id == null) {
+    if (id === undefined) {
         id = wb.styleData.borders.push(thisBorder) - 1;
         wb.styleDataLookup.borders[lookupKey] = id;
     }

--- a/source/lib/workbook/workbook.js
+++ b/source/lib/workbook/workbook.js
@@ -99,7 +99,7 @@ class Workbook {
             'borders': this.styleData.borders.reduce((ret, border, index) => {
                 ret[JSON.stringify(border.toObject())] = index;
                 return ret;
-            }, {}),
+            }, {})
         };
 
         // Set Default Font and Style

--- a/tests/style.test.js
+++ b/tests/style.test.js
@@ -263,3 +263,163 @@ test('Use Workbook default fonts', (t) => {
     t.end();
 });
 
+test('Reuse existing styles', (t) => {
+    // TODO: Needs tests for remaining style props and should test all iterations
+
+    const fontA = {
+        size: 14,
+        name: 'Helvetica',
+        underline: true
+    };
+
+    const fontB = {
+        size: 20,
+        name: 'Arial',
+        underline: true
+    };
+
+    const borderA = {
+        left: {
+            style: 'thin',
+            color: '#444444'
+        },
+        right: {
+            style: 'thin',
+            color: '#444444'
+        },
+        top: {
+            style: 'thin',
+            color: '#444444'
+        },
+        bottom: {
+            style: 'thin',
+            color: '#444444'
+        }
+    };
+
+    const borderB = {
+        left: {
+            style: 'thin',
+            color: '#111111'
+        },
+        right: {
+            style: 'thin',
+            color: '#222222'
+        },
+        top: {
+            style: 'thin',
+            color: '#333333'
+        },
+        bottom: {
+            style: 'thin',
+            color: '#444444'
+        }
+    };
+
+    const fillA = {
+        type: 'pattern',
+        patternType: 'solid',
+        fgColor: 'Yellow'
+    };
+
+    const fillB = {
+        type: 'pattern',
+        patternType: 'lightDown',
+        fgColor: 'Red'
+    };
+
+    function testCombination(isEqual, styleOptsA, styleOptsB, message) {
+        let wb = new xl.Workbook();
+        let prevStyleCount = wb.styles.length;
+        let styleA = wb.createStyle(JSON.parse(JSON.stringify(styleOptsA)));
+        let styleB = wb.createStyle(JSON.parse(JSON.stringify(styleOptsB)));
+        if (isEqual) {
+            t.equal(styleA, styleB, message + ' return same Style instance');
+            t.equal(wb.styles.length, prevStyleCount + 1, message + ' only added one style to workbook');
+        }
+        else {
+            t.notEqual(styleA, styleB, message + ' return different Style instance');
+            t.equal(wb.styles.length, prevStyleCount + 2, message + ' added two styles to workbook');
+        }
+    }
+
+    testCombination(true, {
+        font: fontA
+    }, {
+        font: fontA
+    }, 'Same font');
+
+    testCombination(false, {
+        font: fontA
+    }, {
+        font: fontB
+    }, 'Different fonts');
+
+    testCombination(true, {
+        border: borderA
+    }, {
+        border: borderA
+    }, 'Same border');
+
+    testCombination(false, {
+        border: borderA
+    }, {
+        border: borderB
+    }, 'Different borders');
+
+    testCombination(true, {
+        fill: fillA
+    }, {
+        fill: fillA
+    }, 'Same fill');
+
+    testCombination(false, {
+        fill: fillA
+    }, {
+        fill: fillB
+    }, 'Different fills');
+
+    testCombination(true, {
+        font: fontA,
+        border: borderA
+    }, {
+        font: fontA,
+        border: borderA
+    }, 'Same font and border');
+
+    testCombination(false, {
+        font: fontA,
+        border: borderA
+    }, {
+        font: fontA,
+        border: borderB
+    }, 'Same font different borders');
+
+    testCombination(false, {
+        font: fontA,
+        border: borderA
+    }, {
+        font: fontB,
+        border: borderA
+    }, 'Different font same borders');
+
+    testCombination(false, {
+        font: fontA,
+        fill: fillA
+    }, {
+        font: fontA,
+        fill: fillB
+    }, 'Same font different fills');
+
+    testCombination(true, {
+        font: fontA,
+        border: borderA,
+        fill: fillA
+    }, {
+        font: fontA,
+        border: borderA,
+        fill: fillA
+    }, 'Same font, border and fill');
+
+    t.end();
+});


### PR DESCRIPTION
Discovered via profiling that c82b9c9b4a21f3e73ed681bcda333a371934f3e2 did not completely remove duplicates, and due to array iteration also created a huge bottleneck that caused substantial overhead in  large workbooks. A lot of this time was spent in _.isEqual calls, which can be relatively expensive.

This merge request will...
- Add new tests for duplication of styles (that failed before fix)
- Fix duplicate checking by using a lookup using stringified Style#toObject as the key
- Improve performance of finding duplicate borders, fills and fonts by using lookups