### PR TITLE
Add code coverage with nyc/istanbul

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,8 @@
 { 
-	"presets": ["es2015-node4"]
+	"presets": ["es2015-node4"],
+	"env": {
+		"test": {
+			"plugins": ["istanbul"]
+		}
+	}
 }

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ docs
 output
 tmp
 references
+coverage
+.nyc_output

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "scripts": {
     "test": "NODE_ENV=test ./node_modules/tape/bin/tape -r babel-register ./tests/*.test.js",
+    "cover": "NODE_ENV=test nyc tape -r babel-register ./tests/*.test.js",
     "build": "./node_modules/babel-cli/bin/babel.js source --presets babel-preset-es2015 -s --out-dir distribution",
     "watch": "./node_modules/babel-cli/bin/babel.js source -w --presets babel-preset-es2015 -s --out-dir distribution",
     "document": "jsdoc ./source -r -d docs",
@@ -52,14 +53,24 @@
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",
+    "babel-plugin-istanbul": "^2.0.3",
     "babel-polyfill": "^6.9.1",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-es2015-node4": "^2.1.0",
     "jsdoc-babel": "^0.2.1",
+    "nyc": "^8.4.0",
     "source-map-support": "^0.4.1",
     "tape": "^4.6.0",
     "tape-promise": "^1.1.0",
     "xmldom": "^0.1.22",
     "xpath.js": "^1.0.6"
+  },
+  "nyc": {
+    "instrument": false,
+    "sourceMap": false,
+    "reporter": [
+      "text-summary",
+      "html"
+    ]
   }
 }


### PR DESCRIPTION
To generate the coverage report execute `npm run cover`. A short summary
will will be displayed on the screen and the full report will be
available in ./coverage/index.html

```
=============================== Coverage summary ===============================
Statements   : 54.21% ( 2832/5224 )
Branches     : 33.6% ( 995/2961 )
Functions    : 53.7% ( 494/920 )
Lines        : 52.1% ( 2531/4858 )
================================================================================
```