### PR TITLE
Support option to hide 'view' GridLines

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Full Worksheet options. All options are optional.
             'ySplit': Float // Vertical position of the split, in 1/20th of a point; 0 (zero) if none. If the pane is frozen, this value indicates the number of rows visible in the left pane.
         },
         'rightToLeft': Boolean, // Flag indicating whether the sheet is in 'right to left' display mode. When in this mode, Column A is on the far right, Column B ;is one column left of Column A, and so on. Also, information in cells is displayed in the Right to Left format.
+        'showGridLines': Boolean, // Flag indicating whether the sheet should have gridlines enabled or disabled during view
         'zoomScale': Integer, // Defaults to 100
         'zoomScaleNormal': Integer, // Defaults to 100
         'zoomScalePageLayoutView': Integer // Defaults to 100

--- a/source/lib/worksheet/builder.js
+++ b/source/lib/worksheet/builder.js
@@ -64,6 +64,7 @@ let _addSheetViews = (promiseObj) => {
         let ele = promiseObj.xml.ele('sheetViews');
         let tabSelected = promiseObj.ws.opts;
         let sv = ele.ele('sheetView')
+        .att('showGridLines', false)
         .att('tabSelected', o.tabSelected)
         .att('workbookViewId', o.workbookViewId)
         .att('rightToLeft', o.rightToLeft)

--- a/source/lib/worksheet/builder.js
+++ b/source/lib/worksheet/builder.js
@@ -64,7 +64,7 @@ let _addSheetViews = (promiseObj) => {
         let ele = promiseObj.xml.ele('sheetViews');
         let tabSelected = promiseObj.ws.opts;
         let sv = ele.ele('sheetView')
-        .att('showGridLines', false)
+        .att('showGridLines', o.showGridLines)
         .att('tabSelected', o.tabSelected)
         .att('workbookViewId', o.workbookViewId)
         .att('rightToLeft', o.rightToLeft)

--- a/source/lib/worksheet/optsValidator.js
+++ b/source/lib/worksheet/optsValidator.js
@@ -59,6 +59,7 @@ const optsTypes = {
         'tabSelected': null,
         'workbookViewId': null,
         'rightToLeft': null,
+        'showGridLines': null,
         'zoomScale': null,
         'zoomScaleNormal': null,
         'zoomScalePageLayoutView': null

--- a/source/lib/worksheet/sheet_default_params.js
+++ b/source/lib/worksheet/sheet_default_params.js
@@ -57,6 +57,7 @@ module.exports = {
         'tabSelected': 0,
         'workbookViewId': 0,
         'rightToLeft': 0,
+        'showGridLines': 1,
         'zoomScale': 100,
         'zoomScaleNormal': 100,
         'zoomScalePageLayoutView': 100

--- a/source/lib/worksheet/worksheet.js
+++ b/source/lib/worksheet/worksheet.js
@@ -68,6 +68,7 @@ class Worksheet {
      * @param {String} opts.sheetView.pane.xSplit Horizontal position of the split, in 1/20th of a point; 0 (zero) if none. If the pane is frozen, this value indicates the number of columns visible in the top pane.
      * @param {String} opts.sheetView.pane.ySplit Vertical position of the split, in 1/20th of a point; 0 (zero) if none. If the pane is frozen, this value indicates the number of rows visible in the left pane.
      * @param {Boolean} opts.sheetView.rightToLeft Flag indicating whether the sheet is in 'right to left' display mode. When in this mode, Column A is on the far right, Column B ;is one column left of Column A, and so on. Also, information in cells is displayed in the Right to Left format.
+     * @param {Boolean} opts.sheetView.showGridLines Flag indicating whether the sheet should have gridlines enabled or disabled during view.
      * @param {Number} opts.sheetView.zoomScale  Defaults to 100
      * @param {Number} opts.sheetView.zoomScaleNormal Defaults to 100
      * @param {Number} opts.sheetView.zoomScalePageLayoutView Defaults to 100

--- a/tests/worksheet.test.js
+++ b/tests/worksheet.test.js
@@ -80,6 +80,7 @@ test('Set WorkSheet options', (t) => {
                 'ySplit': 3 // Vertical position of the split, in 1/20th of a point; 0 (zero) if none. If the pane is frozen, this value indicates the number of rows visible in the left pane.
             },
             'rightToLeft': false, // Flag indicating whether the sheet is in 'right to left' display mode. When in this mode, Column A is on the far right, Column B ;is one column left of Column A, and so on. Also, information in cells is displayed in the Right to Left format.
+            'showGridLines': false, // Flag indicating whether the sheet should have gridlines enabled or disabled during view
             'zoomScale': 110, // Defaults to 100
             'zoomScaleNormal': 120, // Defaults to 100
             'zoomScalePageLayoutView': 130 // Defaults to 100
@@ -170,6 +171,7 @@ test('Set WorkSheet options', (t) => {
         t.equals(sheetView.getAttribute('tabSelected'), '1', 'sheetView tabSelected was set correctly');
         t.equals(sheetView.getAttribute('workbookViewId'), '0', 'sheetView workbookViewId was set correctly');
         t.equals(sheetView.getAttribute('rightToLeft'), 'false', 'sheetView rightToLeft was set correctly');
+        t.equals(sheetView.getAttribute('showGridLines'), 'false', 'sheetView showGridLines was set correctly');
         t.equals(sheetView.getAttribute('zoomScale'), '110', 'sheetView zoomScale was set correctly');
         t.equals(sheetView.getAttribute('zoomScaleNormal'), '120', 'sheetView zoomScaleNormal was set correctly');
         t.equals(sheetView.getAttribute('zoomScalePageLayoutView'), '130', 'sheetView zoomScalePageLayoutView was set correctly');


### PR DESCRIPTION
The module already supports a similar setting for printing, but not for viewing, which is supported by the XML structure and in Excel itself. 

This change defaults to current behavior, where the grid lines are included!

Documentation updates, tests and validation of the new property are included.