### PR TITLE
babel-register is not used at runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "prepublish": "npm run build; npm run test"
   },
   "dependencies": {
-    "babel-register": "^6.9.0",
     "colors": "^1.1.2",
     "image-size": "0.5.0",
     "jszip": "^3.0.0",
@@ -55,6 +54,7 @@
     "babel-polyfill": "^6.9.1",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-es2015-node4": "^2.1.0",
+    "babel-register": "^6.9.0",
     "jsdoc-babel": "^0.2.1",
     "source-map-support": "^0.4.1",
     "tape": "^4.6.0",


### PR DESCRIPTION
Hi and thanks for a great library!

I built the code and I grepped it and it does not look like babel-register is useful at runtime.

Just a small detail but everything adds up and in this case, babel-register depends on core-js which amounts to 6.9MB.

Let me know if I missed something.
Cheers!