### PR TITLE
Fixes to support summaryBelow and summaryRight.

### DIFF
--- a/source/lib/worksheet/builder.js
+++ b/source/lib/worksheet/builder.js
@@ -28,8 +28,8 @@ let _addSheetPr = (promiseObj) => {
             if (o.outline.summaryBelow !== null || o.outline.summaryRight !== null) {
                 let outlineEle = ele.ele('outlinePr');
                 outlineEle.att('applyStyles', 1);
-                o.outline.summaryBelow === true ? outlineEle.att('summaryBelow', 1) : null;
-                o.outline.summaryRight === true ? outlineEle.att('summaryRight', 1) : null;
+                o.outline.summaryBelow === true ? outlineEle.att('summaryBelow', 1) : outlineEle.att('summaryBelow', 0);
+                o.outline.summaryRight === true ? outlineEle.att('summaryRight', 1) : outlineEle.att('summaryRight', 0);
                 outlineEle.up();
             }
 

--- a/source/lib/worksheet/builder.js
+++ b/source/lib/worksheet/builder.js
@@ -28,8 +28,8 @@ let _addSheetPr = (promiseObj) => {
             if (o.outline.summaryBelow !== null || o.outline.summaryRight !== null) {
                 let outlineEle = ele.ele('outlinePr');
                 outlineEle.att('applyStyles', 1);
-                o.outline.summaryBelow === true ? outlineEle.att('summaryBelow', 1) : outlineEle.att('summaryBelow', 0);
-                o.outline.summaryRight === true ? outlineEle.att('summaryRight', 1) : outlineEle.att('summaryRight', 0);
+                outlineEle.att('summaryBelow',  o.outline.summaryBelow === true ? 1 : 0);
+                outlineEle.att('summaryRight',  o.outline.summaryRight === true ? 1 : 0);
                 outlineEle.up();
             }
 


### PR DESCRIPTION
when summaryBelow/summaryRight is set false, if we didn't set ('summaryBelow', 0) , it will use excel's default setting and summaryBelow/summaryRight doesn't work.