### PR TITLE
Added: image buffer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,7 +593,6 @@ oneCellAnchor and twoCellAnchor types will take positional objects:
 position type of oneCellAnchor will take a single "from" position   
 position type of twoCellAnchor will take a "from" and "to" position   
 specifying a twoCellAnchor will automatically adjust the image to fit within the bounds of the two anchors.   
-
 ```javascript
 
 ws.addImage({
@@ -639,5 +638,18 @@ ws.addImage({
         }
     }
 });
+```
 
+You can also pass buffer with loaded to memory image:
+```javascript
+ws.addImage({
+    image: fs.readFileSync(path.resolve(__dirname, '../sampleFiles/logo.png')),
+    name: 'logo', // name is not required param
+    type: 'picture',
+    position: {
+        type: 'absoluteAnchor',
+        x: '1in',
+        y: '2in'
+    }
+});
 ```

--- a/source/lib/workbook/builder.js
+++ b/source/lib/workbook/builder.js
@@ -405,7 +405,9 @@ let addDrawingsXML = (promiseObj) => {
 
                         if (d.kind === 'image') {
                             let target = 'image' + d.id + '.' + d.extension;
-                            promiseObj.xlsx.folder('xl').folder('media').file(target, fs.readFileSync(d.imagePath));
+
+                            let image = d.imagePath ? fs.readFileSync(d.imagePath) : d.image;
+                            promiseObj.xlsx.folder('xl').folder('media').file(target, image);
 
                             drawingRelXML.ele('Relationship')
                             .att('Id', d.rId)

--- a/source/lib/workbook/mediaCollection.js
+++ b/source/lib/workbook/mediaCollection.js
@@ -5,9 +5,12 @@ class MediaCollection {
         this.items = [];
     }
 
-    add(filePath) {
-        fs.accessSync(filePath, fs.R_OK);
-        this.items.push(filePath);
+    add(item) {
+        if (typeof item === 'string') {
+            fs.accessSync(item, fs.R_OK);
+        }
+
+        this.items.push(item);
         return this.items.length;
     }
 

--- a/source/lib/worksheet/worksheet.js
+++ b/source/lib/worksheet/worksheet.js
@@ -216,6 +216,8 @@ class Worksheet {
      * @func Worksheet.addImage
      * @param {Object} opts
      * @param {String} opts.path File system path of image
+     * @param {Buffer} opts.image Buffer with image (against read file from opts.path)
+     * @param {String} opts.name Name of image
      * @param {String} opts.type Type of image. Currently only 'picture' is supported
      * @param {Object} opts.position Position object for image
      * @param {String} opts.position.type Type of positional anchor to use. One of 'absoluteAnchor', 'oneCellAnchor', 'twoCellAnchor'
@@ -234,7 +236,7 @@ class Worksheet {
      */
     addImage(opts) {
         opts = opts ? opts : {};
-        let mediaID = this.wb.mediaCollection.add(opts.path);
+        let mediaID = this.wb.mediaCollection.add(opts.path || opts.image);
         let newImage = this.drawingCollection.add(opts);
         newImage.id = mediaID;
 

--- a/tests/image.test.js
+++ b/tests/image.test.js
@@ -4,6 +4,7 @@ const test = _tape(tape);
 const xl = require('../source/index');
 const Picture = require('../source/lib/drawing/picture.js');
 const path = require('path');
+const fs = require('fs');
 
 test('Test adding images', (t) => {
     var wb = new xl.Workbook();
@@ -34,8 +35,9 @@ test('Test adding images', (t) => {
     });
      
     ws.addImage({
-        path: path.resolve(__dirname, '../sampleFiles/logo.png'),
+        image: fs.readFileSync(path.resolve(__dirname, '../sampleFiles/logo.png')),
         type: 'picture',
+        fileName: 'logo.png',
         position: {
             type: 'twoCellAnchor',
             from: {


### PR DESCRIPTION
This PR adds the node buffer support for adding images.

Use the `image` attribute to pass a buffer with the loaded image. Since it can't get the picture name from the `filePath` attribute, you can pass the name explicitly, otherwise, the name is generated automatically.  

```javascript
ws.addImage({
    image: fs.readFileSync(path.resolve(__dirname, '../sampleFiles/logo.png')),
    name: 'logo', // name is not required param
    type: 'picture',
    position: {
        type: 'absoluteAnchor',
        x: '1in',
        y: '2in'
    }
});
```

**Upd:**
Until the PR isn't approved I published the package in my namespace on npm: https://www.npmjs.com/package/@marcuzzzy/excel4node