### PR TITLE
use allowSurrogateChars for emoji support

### DIFF
--- a/source/lib/workbook/builder.js
+++ b/source/lib/workbook/builder.js
@@ -11,7 +11,8 @@ let addRootContentTypesXML = (promiseObj) => {
             {
                 'version': '1.0', 
                 'encoding': 'UTF-8', 
-                'standalone': true
+                'standalone': true,
+                'allowSurrogateChars': true
             }
         )
         .att('xmlns', 'http://schemas.openxmlformats.org/package/2006/content-types');
@@ -224,7 +225,8 @@ let addSharedStringsXML = (promiseObj) => {
             {
                 'version': '1.0', 
                 'encoding': 'UTF-8', 
-                'standalone': true
+                'standalone': true,
+                'allowSurrogateChars': true
             }
         )
         .att('count', promiseObj.wb.sharedStrings.length)
@@ -315,7 +317,8 @@ let addStylesXML = (promiseObj) => {
             {
                 'version': '1.0', 
                 'encoding': 'UTF-8', 
-                'standalone': true
+                'standalone': true,
+                'allowSurrogateChars': true
             }
         )
         .att('mc:Ignorable', 'x14ac')

--- a/source/lib/worksheet/builder.js
+++ b/source/lib/worksheet/builder.js
@@ -453,9 +453,12 @@ let sheetXML = (ws) => {
 
         let xmlProlog = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
         let xmlString = '';
-        let wsXML = xml.begin((chunk) => {
+        let wsXML = xml.begin({
+          allowSurrogateChars: true,
+        }, (chunk) => {
             xmlString += chunk;
         })
+        
         .ele('worksheet')
         .att('mc:Ignorable', 'x14ac')
         .att('xmlns', 'http://schemas.openxmlformats.org/spreadsheetml/2006/main')
@@ -514,7 +517,8 @@ let relsXML = (ws) => {
             {
                 'version': '1.0', 
                 'encoding': 'UTF-8', 
-                'standalone': true
+                'standalone': true,
+                'allowSurrogateChars': true
             }
         );
         relXML.att('xmlns', 'http://schemas.openxmlformats.org/package/2006/relationships');


### PR DESCRIPTION
Fairly self-explanatory. This module is useless when text contains emojis unless the proper xmlbuilder option is set. This PR enables the proper configuration to allow emoji in cell strings.

It appears this was addressed long ago in commit 8c4ca08 but the fix seems to have been lost along the way.