### PR TITLE
fix incorrect definition of row spans and add option to disable them

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,8 @@ Full Worksheet options. All options are optional.
     'outline': {
         'summaryBelow': Boolean, // Flag indicating whether summary rows appear below detail in an outline, when applying an outline/grouping.
         'summaryRight': Boolean // Flag indicating whether summary columns appear to the right of detail in an outline, when applying an outline/grouping.
-    }
+    },
+    'disableRowSpansOptimization': Boolean // Flag indicating whether to remove the "spans" attribute on row definitions. Including spans in an optimization for Excel file readers but is not necessary
 }
 ```
 

--- a/source/lib/row/row.js
+++ b/source/lib/row/row.js
@@ -71,10 +71,12 @@ class Row {
     }
 
     get spans() {
-        if (this.cellRefs instanceof Array && this.cellRefs.length > 0) {
-            return `${utils.getExcelRowCol(this.cellRefs[0]).row}:${utils.getExcelRowCol(this.cellRefs[this.cellRefs.length - 1]).row}`;
+        if (this.cellRefs.length > 0) {
+            const startCol = utils.getExcelRowCol(this.cellRefs[0]).col;
+            const endCol = utils.getExcelRowCol(this.cellRefs[this.cellRefs.length - 1]).col;
+            return `${startCol}:${endCol}`;
         } else {
-            return `${this.r}:${this.r}`;
+            return null;
         }
     }
 

--- a/source/lib/worksheet/builder.js
+++ b/source/lib/worksheet/builder.js
@@ -157,7 +157,9 @@ let _addSheetData = (promiseObj) => {
                 let rEle = ele.ele('row');
 
                 rEle.att('r', thisRow.r);
-                rEle.att('spans', thisRow.spans);
+                if (promiseObj.ws.opts.disableRowSpansOptimization !== true && thisRow.spans) {
+                    rEle.att('spans', thisRow.spans);
+                }
                 thisRow.s !== null ? rEle.att('s', thisRow.s) : null;
                 thisRow.customFormat !== null ? rEle.att('customFormat', thisRow.customFormat) : null;
                 thisRow.ht !== null ? rEle.att('ht', thisRow.ht) : null;

--- a/source/lib/worksheet/sheet_default_params.js
+++ b/source/lib/worksheet/sheet_default_params.js
@@ -104,5 +104,6 @@ module.exports = {
         'endCol': null,
         'ref': null,
         'filters': []
-    }
+    },
+    'disableRowSpansOptimization': false,
 };

--- a/source/lib/worksheet/worksheet.js
+++ b/source/lib/worksheet/worksheet.js
@@ -99,6 +99,7 @@ class Worksheet {
      * @param {Object} opts.outline 
      * @param {Boolean} opts.outline.summaryBelow Flag indicating whether summary rows appear below detail in an outline, when applying an outline/grouping.
      * @param {Boolean} opts.outline.summaryRight Flag indicating whether summary columns appear to the right of detail in an outline, when applying an outline/grouping.
+     * @param {Boolean} opts.disableRowSpansOptimization Flag indicated whether to not include a spans attribute to the row definition in the XML. helps with very large documents.
      * @returns {Worksheet}
      */
     constructor(wb, name, opts) {


### PR DESCRIPTION
spans were reporting the row when they should have been reporting the columns that were spanned as defined in §18.3.1.73 of reference guide