### PR TITLE
Allow to use with bundler

### DIFF
--- a/source/lib/types/index.js
+++ b/source/lib/types/index.js
@@ -1,9 +1,16 @@
-let fs = require('fs');
-let path = require('path');
-let dirItems = fs.readdirSync(__dirname);
+'use strict';
 
-dirItems.forEach((i) => {
-    if (i !== 'index.js' && i.substr(i.length - 3, 3) === '.js') {
-        module.exports[i.substr(0, i.length - 3)] = require(path.resolve(__dirname, i));
-    }
-});
+exports.alignment = require('./alignment');
+exports.borderStyle = require('./borderStyle');
+exports.cellComment = require('./cellComment');
+exports.colorScheme = require('./colorScheme');
+exports.excelColor = require('./excelColor');
+exports.fillPattern = require('./fillPattern');
+exports.fontFamily = require('./fontFamily');
+exports.orientation = require('./orientation');
+exports.pageOrder = require('./pageOrder');
+exports.pane = require('./pane');
+exports.paneState = require('./paneState');
+exports.paperSize = require('./paperSize');
+exports.positiveUniversalMeasure = require('./positiveUniversalMeasure');
+exports.printError = require('./printError');


### PR DESCRIPTION
Hi! Thanks for this nice library. I found it easy to get started with.

I'm deploying this in an AWS Lambda function. To reduce cold start time, I'm using a bundler to jam all JS into a single file. The bundler isn't able to resolve the dynamic module loading that is used in `source/lib/types/index.js`.

This was the only place I found and with this change, it works great.