### PR TITLE
Adds support for xml 1.1 valid characters... like emoji

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "excel4node",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Library to create Formatted Excel Files.",
   "engines": {
-    "node": ">4.0.0"
+    "node": ">6.0.0"
   },
   "keywords": [
     "excel",

--- a/source/lib/cell/index.js
+++ b/source/lib/cell/index.js
@@ -16,15 +16,15 @@ function stringSetter(val) {
         val = '';
     }
 
-    let chars, chr;
-    chars = /[\u0000-\u0008\u000B-\u000C\u000E-\u001F\uD800-\uDFFF\uFFFE-\uFFFF]/;
-    chr = val.match(chars);
+    let invalidXml11Chars, chr;
+    invalidXml11Chars = /[^\u0001-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF]/u;
+    chr = val.match(invalidXml11Chars);
     if (chr) {
         logger.warn('Invalid Character for XML "' + chr + '" in string "' + val + '"');
         val = val.replace(chr, '');
     }
     // Remove Control characters, they aren't understood by xmlbuilder
-    val = val.replace(/[\u0000-\u0008\u000B-\u000C\u000E-\u001F\uD800-\uDFFF\uFFFE-\uFFFF]/, '');
+    val = val.replace(invalidXml11Chars, '');
 
     if (!this.merged) {
         this.cells.forEach((c) => {

--- a/source/lib/workbook/builder.js
+++ b/source/lib/workbook/builder.js
@@ -62,7 +62,8 @@ let addRootRelsXML = (promiseObj) => {
         'Relationships', {
           'version': '1.0',
           'encoding': 'UTF-8',
-          'standalone': true
+          'standalone': true,
+          'allowSurrogateChars': true
         }
       )
       .att('xmlns', 'http://schemas.openxmlformats.org/package/2006/relationships');
@@ -88,7 +89,8 @@ let addWorkbookXML = (promiseObj) => {
       'workbook', {
         'version': '1.0',
         'encoding': 'UTF-8',
-        'standalone': true
+        'standalone': true,
+        'allowSurrogateChars': true
       }
     );
     xml.att('mc:Ignorable', 'x15');
@@ -174,7 +176,8 @@ let addWorkbookRelsXML = (promiseObj) => {
         'Relationships', {
           'version': '1.0',
           'encoding': 'UTF-8',
-          'standalone': true
+          'standalone': true,
+          'allowSurrogateChars': true
         }
       )
       .att('xmlns', 'http://schemas.openxmlformats.org/package/2006/relationships');
@@ -424,7 +427,8 @@ let addDrawingsXML = (promiseObj) => {
           let drawingRelXML = xmlbuilder.create('Relationships', {
               'version': '1.0',
               'encoding': 'UTF-8',
-              'standalone': true
+              'standalone': true,
+              'allowSurrogateChars': true
             })
             .att('xmlns', 'http://schemas.openxmlformats.org/package/2006/relationships');
 
@@ -432,7 +436,8 @@ let addDrawingsXML = (promiseObj) => {
             'xdr:wsDr', {
               'version': '1.0',
               'encoding': 'UTF-8',
-              'standalone': true
+              'standalone': true,
+              'allowSurrogateChars': true
             }
           );
           drawingsXML
@@ -477,7 +482,7 @@ let addDrawingsXML = (promiseObj) => {
  * @private
  * @memberof Workbook
  * @param {Workbook} wb Workbook instance
- * @return {Promise} resolves with Buffer 
+ * @return {Promise} resolves with Buffer
  */
 let writeToBuffer = (wb) => {
   return new Promise((resolve, reject) => {
@@ -519,7 +524,7 @@ let writeToBuffer = (wb) => {
 /**
  * @desc Currently only used for testing the XML generated for a Workbook.
  * @param {*} wb Workbook instance
- * @return {Promise} resolves with Workbook XML 
+ * @return {Promise} resolves with Workbook XML
  */
 let workbookXML = (wb) => {
   let promiseObj = {

--- a/source/lib/worksheet/builder.js
+++ b/source/lib/worksheet/builder.js
@@ -11,8 +11,8 @@ let _addSheetPr = (promiseObj) => {
 
         // Check if any option that would require the sheetPr element to be added exists
         if (
-            o.printOptions.fitToHeight !== null || 
-            o.printOptions.fitToWidth !== null || 
+            o.printOptions.fitToHeight !== null ||
+            o.printOptions.fitToWidth !== null ||
             o.outline.summaryBelow !== null ||
             o.autoFilter.ref !== null ||
             o.outline.summaryRight
@@ -124,7 +124,7 @@ let _addCols = (promiseObj) => {
             for (let colId in promiseObj.ws.cols) {
                 let col = promiseObj.ws.cols[colId];
                 let colEle = colsEle.ele('col');
-                
+
                 col.min !== null ? colEle.att('min', col.min) : null;
                 col.max !== null ? colEle.att('max', col.max) : null;
                 col.width !== null ? colEle.att('width', col.width) : null;
@@ -173,7 +173,7 @@ let _addSheetData = (promiseObj) => {
                 for (var i = 0; i < thisRow.cellRefs.length; i++) {
                     promiseObj.ws.cells[thisRow.cellRefs[i]].addToXMLele(rEle);
                 }
-                
+
                 rEle.up();
             }
 
@@ -219,7 +219,7 @@ let _addSheetProtection = (promiseObj) => {
                     } else {
                         ele.att(k, utils.boolToInt(o[k]));
                     }
-                }            
+                }
             });
             ele.up();
         }
@@ -268,10 +268,10 @@ let _addAutoFilter = (promiseObj) => {
                 localSheetId: promiseObj.ws.localSheetId,
                 name: '_xlnm._FilterDatabase',
                 refFormula: '\'' + promiseObj.ws.name + '\'!' +
-                    '$' + utils.getExcelAlpha(o.startCol) + 
+                    '$' + utils.getExcelAlpha(o.startCol) +
                     '$' + o.startRow +
                     ':' +
-                    '$' + utils.getExcelAlpha(o.endCol) + 
+                    '$' + utils.getExcelAlpha(o.endCol) +
                     '$' + o.endRow
             });
             ele.up();
@@ -457,11 +457,11 @@ let sheetXML = (ws) => {
         let xmlProlog = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
         let xmlString = '';
         let wsXML = xml.begin({
-          allowSurrogateChars: true,
+          'allowSurrogateChars': true,
         }, (chunk) => {
             xmlString += chunk;
         })
-        
+
         .ele('worksheet')
         .att('mc:Ignorable', 'x14ac')
         .att('xmlns', 'http://schemas.openxmlformats.org/spreadsheetml/2006/main')
@@ -513,13 +513,13 @@ let relsXML = (ws) => {
 
         if (sheetRelRequired === false) {
             resolve();
-        } 
+        }
 
         let relXML = xml.create(
             'Relationships',
             {
-                'version': '1.0', 
-                'encoding': 'UTF-8', 
+                'version': '1.0',
+                'encoding': 'UTF-8',
                 'standalone': true,
                 'allowSurrogateChars': true
             }
@@ -533,7 +533,7 @@ let relsXML = (ws) => {
                 .att('Id', rId)
                 .att('Target', r.location)
                 .att('TargetMode', 'External')
-                .att('Type', 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink');                
+                .att('Type', 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink');
             } else if (r === 'drawing') {
                 relXML.ele('Relationship')
                 .att('Id', rId)
@@ -547,4 +547,3 @@ let relsXML = (ws) => {
 };
 
 module.exports = { sheetXML, relsXML };
-

--- a/tests/emoji.test.js
+++ b/tests/emoji.test.js
@@ -1,0 +1,19 @@
+let test = require('tape');
+let xl = require('../source/index');
+
+function testEmoji(t, wb, ws, cellIndex, strVal) {
+    let cellAccessor = ws.cell(1, cellIndex);
+    let cell = cellAccessor.string(strVal);
+    let thisCell = ws.cells[cell.excelRefs[0]];
+    t.ok(wb.sharedStrings[thisCell.v] === strVal, 'Emoji exists in cell');
+}
+test('Cell coverage', (t) => {
+    let wb = new xl.Workbook();
+    let ws = wb.addWorksheet('test');
+
+    testEmoji(t, wb, ws, 1, '😂');
+    testEmoji(t, wb, ws, 2, 'hello! 😂');
+    testEmoji(t, wb, ws, 3, '😂☕️');
+
+    t.end();
+});


### PR DESCRIPTION
This addresses #75 

TLDR: the original regex in `stringSetter` did not properly support 2-char unicode, missing the trailing `/u` in the regex.

In addition, the character ranges were set up for XML 1.0, not 1.1.

- Fixes the regex itself
- Fixes the regex character ranges
- Adds unit tests.