### PR TITLE
Remove deepmerge dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,12 +42,12 @@
     "prepublish": "npm run build; npm run test"
   },
   "dependencies": {
-    "deepmerge": "2.1.1",
     "image-size": "0.6.3",
     "jszip": "3.1.5",
     "lodash.get": "4.4.2",
     "lodash.isequal": "4.5.0",
     "lodash.isundefined": "3.0.1",
+    "lodash.merge": "4.6.1",
     "lodash.reduce": "4.6.0",
     "lodash.uniqueid": "4.0.1",
     "mime": "2.3.1",

--- a/source/lib/cell/index.js
+++ b/source/lib/cell/index.js
@@ -1,4 +1,4 @@
-const deepmerge = require('deepmerge');
+const _merge = require('lodash.merge');
 const Cell = require('./cell.js');
 const Row = require('../row/row.js');
 const Comment = require('../classes/comment');
@@ -180,7 +180,7 @@ function styleSetter(val) {
             c.style(thisCellStyle.ids.cellXfs);
         } else {
             let curStyle = this.ws.wb.styles[c.s];
-            let newStyleOpts = deepmerge(curStyle.toObject(), thisStyle);
+            let newStyleOpts = _merge(curStyle.toObject(), thisStyle);
             let mergedStyle = this.ws.wb.createStyle(newStyleOpts);
             c.style(mergedStyle.ids.cellXfs);
         }

--- a/source/lib/style/style.js
+++ b/source/lib/style/style.js
@@ -1,5 +1,5 @@
 const utils = require('../utils.js');
-const deepmerge = require('deepmerge');
+const _merge = require('lodash.merge');
 
 const Alignment = require('./classes/alignment.js');
 const Border = require('./classes/border.js');
@@ -10,7 +10,7 @@ const NumberFormat = require('./classes/numberFormat.js');
 let _getFontId = (wb, font = {}) => {
 
     // Create the Font and lookup key
-    font = deepmerge(wb.opts.defaultFont, font);
+    font = _merge(wb.opts.defaultFont, font);
     const thisFont = new Font(font);
     const lookupKey = JSON.stringify(thisFont.toObject());
 
@@ -170,7 +170,7 @@ class Style {
          * @returns {Style} 
          */
         opts = opts ? opts : {};
-        opts = deepmerge(wb.styles[0] ? wb.styles[0] : {}, opts);
+        opts = _merge(wb.styles[0] ? wb.styles[0] : {}, opts);
 
         if (opts.alignment !== undefined) {
             this.alignment = new Alignment(opts.alignment);

--- a/source/lib/workbook/workbook.js
+++ b/source/lib/workbook/workbook.js
@@ -1,5 +1,5 @@
 const _isUndefined = require('lodash.isundefined');
-const deepmerge = require('deepmerge');
+const _merge = require('lodash.merge');
 const fs = require('fs');
 const utils = require('../utils.js');
 const Worksheet = require('../worksheet');
@@ -85,7 +85,7 @@ class Workbook {
             this.logger.log('opts.logger is not a valid logger');
         }
 
-        this.opts = deepmerge(workbookDefaultOpts, opts);
+        this.opts = _merge(workbookDefaultOpts, opts);
         this.author = this.opts.author || 'Microsoft Office User';
 
         this.sheets = [];

--- a/source/lib/worksheet/worksheet.js
+++ b/source/lib/worksheet/worksheet.js
@@ -1,4 +1,4 @@
-const deepmerge = require('deepmerge');
+const _merge = require('lodash.merge');
 const CfRulesCollection = require('./cf/cf_rules_collection');
 const cellAccessor = require('../cell');
 const rowAccessor = require('../row');
@@ -108,7 +108,7 @@ class Worksheet {
         this.wb = wb;
         this.sheetId = this.wb.sheets.length + 1;
         this.localSheetId = this.wb.sheets.length;
-        this.opts = deepmerge(wsDefaultParams, opts);
+        this.opts = _merge(wsDefaultParams, opts);
         optsValidator(opts);
         
         this.name = name ? name : `Sheet ${this.sheetId}`;

--- a/tests/cf_rule.test.js
+++ b/tests/cf_rule.test.js
@@ -1,4 +1,4 @@
-var deepmerge = require('deepmerge');
+var _merge = require('lodash.merge');
 var test = require('tape');
 
 var CfRule = require('../distribution/lib/worksheet/cf/cf_rule');
@@ -16,7 +16,7 @@ test('CfRule init', function (t) {
     t.ok(new CfRule(baseConfig), 'init with valid and support type');
 
     try {
-        var cfr = new CfRule(deepmerge(baseConfig, {
+        var cfr = new CfRule(_merge(baseConfig, {
             type: 'bogusType'
         }));
     } catch (err) {
@@ -27,7 +27,7 @@ test('CfRule init', function (t) {
     }
 
     try {
-        var cfr = new CfRule(deepmerge(baseConfig, {
+        var cfr = new CfRule(_merge(baseConfig, {
             type: 'dataBar'
         }));
     } catch (err) {
@@ -38,7 +38,7 @@ test('CfRule init', function (t) {
     }
 
     try {
-        var cfr = new CfRule(deepmerge(baseConfig, {
+        var cfr = new CfRule(_merge(baseConfig, {
             formula: null
         }));
     } catch (err) {


### PR DESCRIPTION
This partially reverts commit 995e0d1dae2e41fc6c4b04b98e5e8e00d3ae75e7.

When using excel4node on the browser (such as React), deepmerge gives some trouble with webpack.

See issue https://github.com/KyleAMathews/deepmerge/issues/87

This pull request replaces deepmerge with _.merge. I'm not sure if Issue 226 ( #229 ) needed deepmerge for any special reason.