### PR TITLE
Update license format in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,7 @@
     "name": "Nater",
     "email": "nater@iamnater.com"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://opensource.org/licenses/mit-license.php"
-    }
-  ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/natergj/excel4node.git"


### PR DESCRIPTION
"licenses" property is deprecated. From https://docs.npmjs.com/files/package.json:
> Some old packages used license objects or a “licenses” property containing an array of license objects:
> ```
> // Not valid metadata
> { "license" :
>   { "type" : "ISC"
>   , "url" : "https://opensource.org/licenses/ISC"
>   }
> }
> 
> // Not valid metadata
> { "licenses" :
>   [
>     { "type": "MIT"
>     , "url": "https://www.opensource.org/licenses/mit-license.php"
>     }
>   , { "type": "Apache-2.0"
>     , "url": "https://opensource.org/licenses/apache2.0.php"
>     }
>   ]
> }
> ```
> Those styles are now deprecated. Instead, use SPDX expressions, like this:
> ```
> { "license": "ISC" }
> 
> { "license": "(MIT OR Apache-2.0)" }
> ```
Closes #266.