### PR TITLE
Update alignment.js

### DIFF
--- a/source/lib/style/classes/alignment.js
+++ b/source/lib/style/classes/alignment.js
@@ -41,8 +41,6 @@ class Alignment { // §18.8.1 alignment (Alignment)
         if (opts.justifyLastLine !== undefined) {
             if (typeof opts.justifyLastLine === 'boolean') {
                 this.justifyLastLine = opts.justifyLastLine;
-            } else {
-                throw new TypeError('justifyLastLine alignment option must be of type boolean');
             }
         }
 
@@ -57,8 +55,6 @@ class Alignment { // §18.8.1 alignment (Alignment)
         if (opts.shrinkToFit !== undefined) {
             if (typeof opts.shrinkToFit === 'boolean') {
                 this.shrinkToFit = opts.shrinkToFit;
-            } else {
-                throw new TypeError('justifyLastLine alignment option must be of type boolean');
             }
         }
 
@@ -73,9 +69,7 @@ class Alignment { // §18.8.1 alignment (Alignment)
         if (opts.wrapText !== undefined) {
             if (typeof opts.wrapText === 'boolean') {
                 this.wrapText = opts.wrapText;
-            } else {
-                throw new TypeError('justifyLastLine alignment option must be of type boolean');
-            }
+            } 
         }
     }
 


### PR DESCRIPTION
Even in a very simple code, these parts fail. It is also very misleading to throw an error about the "justifyLastLine" object for all processes. Please remove these sections, "justifyLastLine" is defined and throws error even if its type is boolean.

Code 
```
wb.createStyle({ alignment: { horizontal: "center" }});
```
Output : 
  TypeError : justifyLastLine aligment option must be of type boolean