### PR TITLE
fix: upgrade jszip to 3.7.1 to address DOS vulnerability 

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "deepmerge": "3.2.0",
     "image-size": "0.7.2",
-    "jszip": "3.2.1",
+    "jszip": "3.7.1",
     "lodash.get": "4.4.2",
     "lodash.isequal": "4.5.0",
     "lodash.isundefined": "3.0.1",


### PR DESCRIPTION
This is to address a DOS Vulnerability that is introduced by jszip < 3.7.0. See details here: https://app.snyk.io/vuln/SNYK-JS-JSZIP-1251497.

It's a very simple dependency update in `package.json`. I ran the tests and validated the sample Excel doc and all looked good.

<img width="1161" alt="Screen Shot 2021-08-27 at 7 55 14 PM" src="https://user-images.githubusercontent.com/8948739/131199711-91f069af-a366-4023-9783-7f33a02c54f3.png">

