### PR TITLE
Add default cell style definition

### DIFF
--- a/source/lib/workbook/builder.js
+++ b/source/lib/workbook/builder.js
@@ -26,6 +26,7 @@ let addRootContentTypesXML = (promiseObj) => {
             let typeRef = d.contentType + '.' + d.extension;
             if (contentTypesAdded.indexOf(typeRef) < 0) {
               xml.ele('Default').att('ContentType', d.contentType).att('Extension', d.extension);
+              contentTypesAdded.push(typeRef);
             }
             extensionsAdded.push(d.extension);
           }
@@ -486,6 +487,19 @@ let addStylesXML = (promiseObj) => {
       b.addToXMLele(borderXML);
     });
 
+    let cellStyleXfsXML = xml
+      .ele('cellStyleXfs')
+      .att('count', 1);
+    
+    cellStyleXfsXML.ele('xf')
+      .att('numFmtId', '0')
+      .att('fontId', '0')
+      .att('fillId','0')
+      .att('borderId', '0')
+      .att('applyFont', 'true')
+      .att('applyBorder', 'false')
+      .att('applyAlignment', 'false')
+      .att('applyProtection', 'false');
 
     let cellXfsXML = xml
       .ele('cellXfs')
@@ -493,10 +507,20 @@ let addStylesXML = (promiseObj) => {
     promiseObj.wb.styles.forEach((s) => {
       s.addXFtoXMLele(cellXfsXML);
     });
+    
+
+    // insert default cell style
+    let cellStylesXML = xml
+      .ele('cellStyles')
+      .att('count', 1);
+    cellStylesXML.ele('cellStyle')
+      .att('name', 'Normal')
+      .att('xfId', '0')
+      .att('builtinId', '0');
 
     if (promiseObj.wb.dxfCollection.length > 0) {
       promiseObj.wb.dxfCollection.addToXMLele(xml);
-    }
+    } 
 
     let xmlString = xml.doc().end(promiseObj.xmlOutVars);
     promiseObj.xlsx.folder('xl').file('styles.xml', xmlString);


### PR DESCRIPTION
Hi, I have found that XLSX file generated by your library is opened with following warning in `openpyxl`:
```
.local/lib/python3.8/site-packages/openpyxl/styles/stylesheet.py:226: UserWarning: Workbook contains no default style, apply openpyxl's default                                                       
warn("Workbook contains no default style, apply openpyxl's default")   
```
I checked empty Excel file file structure and found that it has `cellStyleXfs`/`cellStyles` elements with default  "Normal" style.
So I have added same definitions to workbook builder.
With these changes tha warning is elminated. 

Also I have fixed logic bug with `contentTypesAdded` used for Content-Types duplication check