### PR TITLE
Update builder.js

### DIFF
--- a/source/lib/workbook/builder.js
+++ b/source/lib/workbook/builder.js
@@ -581,7 +581,7 @@ let writeToBuffer = (wb) => {
     };
 
     if (promiseObj.wb.sheets.length === 0) {
-      promiseObj.wb.Worksheet();
+      promiseObj.wb.addWorksheet();
     }
 
     addRootContentTypesXML(promiseObj)


### PR DESCRIPTION
在微信小程序中 npm安装运行时出现bug，  改了worksheep为addworksheep后没问题了  提示wb.worksheep is not a function,不知道github里是否有同样的问题